### PR TITLE
Make max import threads configurable

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -13,7 +13,7 @@ import (
 
 var force bool
 var newStoragePath, namespace, target string
-var releaseTimeoutSec int
+var releaseTimeoutSec, threads int
 var values map[string]string
 
 var importCmd = &cobra.Command{
@@ -47,6 +47,7 @@ release, you should use the helm delete --purge to delete it first.`,
 			Target:            viper.GetString("target"),
 			Values:            values,
 			ExcludeNamespaces: viper.GetStringSlice("excludeNamespaces"),
+			Threads:           viper.GetInt64("threads"),
 		}
 
 		valid = validateImportConfig()
@@ -65,6 +66,7 @@ func init() { // nolint: dupl
 	importCmd.PersistentFlags().StringVarP(&target, "target-namespace", "", "", "Specify a new namespace to import releases to")
 	importCmd.PersistentFlags().StringToStringVarP(&values, "update-values", "", map[string]string{}, "Specify a mapping of values to update when importing releases. Overrides apply to all releases for which a given value is already set, but will not insert the value if it doesn't already exist")
 	importCmd.PersistentFlags().StringSliceP("exclude-namespaces", "", []string{}, "A list of namespaces to exclude. The default behavior is to import all namespaces")
+	importCmd.PersistentFlags().IntVarP(&threads, "threads", "", 50, "The maximum number of threads to use for installing releases")
 
 	err := bindConfigFlags(importCmd, map[string]string{
 		"force":             "force",
@@ -74,6 +76,7 @@ func init() { // nolint: dupl
 		"target":            "target-namespace",
 		"valueUpdates":      "update-values",
 		"excludeNamespaces": "exclude-namespaces",
+		"threads":           "threads",
 	})
 	if err != nil {
 		fmt.Println(err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,4 +46,5 @@ type ImportConfig struct {
 	Target            string
 	Values            map[string]string
 	ExcludeNamespaces []string
+	Threads           int64
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -36,8 +36,3 @@ const (
 	// ValueStoragePath is the helm --set path for --path
 	ValueStoragePath = "backend.path"
 )
-
-const (
-	// ImportMaxThreads is the maximum number of threads to use for installing releases
-	ImportMaxThreads = 50
-)

--- a/pkg/importt/importt.go
+++ b/pkg/importt/importt.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/logicmonitor/k8s-release-manager/pkg/client"
 	"github.com/logicmonitor/k8s-release-manager/pkg/config"
-	"github.com/logicmonitor/k8s-release-manager/pkg/constants"
 	"github.com/logicmonitor/k8s-release-manager/pkg/lmhelm"
 	"github.com/logicmonitor/k8s-release-manager/pkg/release"
 	"github.com/logicmonitor/k8s-release-manager/pkg/state"
@@ -66,7 +65,7 @@ func (t *Import) Run() error {
 
 func (t *Import) deployReleases(releases []*rls.Release) error {
 	var err error
-	var sem = make(chan int, constants.ImportMaxThreads)
+	var sem = make(chan int, t.Config.Import.Threads)
 	for _, r := range releases {
 		fmt.Printf("Deploying release %s to namespace %s\n", r.GetName(), r.GetNamespace())
 

--- a/pkg/importt/process.go
+++ b/pkg/importt/process.go
@@ -39,9 +39,9 @@ func includeReleasesByNamespace(releases []*rls.Release, config *config.ImportCo
 }
 
 func updateNamespace(releases []*rls.Release, config *config.ImportConfig) []*rls.Release {
-	for _, r := range releases {
-		// update the target namespace if option specified
-		if config.Target != "" {
+	if config.Target != "" {
+		for _, r := range releases {
+			// update the target namespace if option specified
 			r.Namespace = config.Target
 		}
 	}


### PR DESCRIPTION
In certain situations I run into open file limit issues. I'd run into this previously and constrained the number of threads, but under particularly high usage scenarios, running releasemanager can still run into this issue. Making the threads configurable should allow this issue to be circumvented if necessary by reducing the number of threads for a given import operation.